### PR TITLE
update modifier multiplication

### DIFF
--- a/lib/scores.js
+++ b/lib/scores.js
@@ -51,7 +51,7 @@ function getBase(vector, options) {
 
   var modifier = (scope === 'C') ? 1.08 : 1;
 
-  return exports.formatScore(modifier * impact + exploitability);
+  return exports.formatScore(modifier * (impact + exploitability));
 }
 exports.getBase = getBase;
 

--- a/test/scores.js
+++ b/test/scores.js
@@ -85,6 +85,14 @@ describe('scores', function () {
       expect(scores.getBase({ C: 'N', I: 'N', A: 'N' })).to.equal(0.0);
     });
 
+    it('multiplies by the modifier by the sum of impact and exploitability when S:C is set', function() {
+      /*
+        this vector has high "exploitability"; so it is more impacted by the inclusion or exclusion of this term
+        from the modifier multiplication
+       */
+      expect(scores.getBase({ AV: 'N', C: 'H', S: 'C' })).to.equal(6.2);
+    });
+
     it('calls getExploitability with generated scores and options', function () {
       var oldGetExploitability = scores.getExploitability;
       var exploitabilityCalls = [];


### PR DESCRIPTION
https://github.com/aaronmccall/cvss/issues/5

* Changed getBaseBase to multiply the sum of both exploitability and
  impact rather than just multiplying by impact and adding
  exploitability

* Added test case for a scenario where the modifier will be number other
 than 1 and the exploitability will be high which is where this logic is
 most expressed