### PR TITLE
Calculate correct score in case Environmental Requirements are provided

### DIFF
--- a/lib/scores.js
+++ b/lib/scores.js
@@ -4,8 +4,8 @@ var metrics = require('./metrics');
 function isScopeChanged(scope, modifiedScope, environmental) {
   var scopeMetricToUse;
 
-  if (environmental && modifiedScope) {
-    scopeMetricToUse = modifiedScope === 'X' ? scope : modifiedScope;
+  if (environmental && modifiedScope && modifiedScope !== 'X') {
+    scopeMetricToUse = modifiedScope;
   } else {
     scopeMetricToUse = scope;
   }

--- a/lib/scores.js
+++ b/lib/scores.js
@@ -1,6 +1,18 @@
 var keys = require('./keys');
 var metrics = require('./metrics');
 
+function isScopeChanged(scope, modifiedScope, environmental) {
+  var scopeMetricToUse;
+
+  if (environmental && modifiedScope) {
+    scopeMetricToUse = modifiedScope === 'X' ? scope : modifiedScope;
+  } else {
+    scopeMetricToUse = scope;
+  }
+
+  return scopeMetricToUse === 'C';
+}
+
 function formatScore(score) {
   return Math.ceil(Math.min(score, 10) * 10.0) / 10.0;
 }
@@ -21,9 +33,7 @@ function getImpact(scores, vector, options) {
     return result * (1 - scores[key]);
   }, 1)), isEnv ? 0.915 : Infinity);
 
-  var scope = options && options.env ? vector.MS : vector.S;
-
-  if (scope !== 'C') {
+  if (!isScopeChanged(vector.S, vector.MS, isEnv)) {
     return (6.42 * baseImpact);
   }
 
@@ -47,9 +57,7 @@ function getBase(vector, options) {
 
   var exploitability = exports.getExploitability(scoreObj, options);
 
-  var scope = (options && options.env) ? (vector.MS || vector.S) : vector.S;
-
-  var modifier = (scope === 'C') ? 1.08 : 1;
+  var modifier = isScopeChanged(vector.S, vector.MS, (options || {}).env) ? 1.08 : 1;
 
   return exports.formatScore(modifier * (impact + exploitability));
 }

--- a/test/scores.js
+++ b/test/scores.js
@@ -114,6 +114,12 @@ describe('scores', function () {
 
       scores.getExploitability = oldGetExploitability;
     });
+
+    it('returns the correct environmental score for vector without modifiers', function () {
+      var someVector = parseVector('CVSS:3.0/AV:N/AC:H/PR:L/UI:N/S:C/C:L/I:L/A:L/CR:H/IR:H/AR:H/MS:X');
+
+      expect(scores.getBase(someVector, { env: true })).to.equal(7.4);
+    });
   });
 
   describe('#getTemporal', function () {


### PR DESCRIPTION
Fixes https://github.com/aaronmccall/cvss/issues/19

This MR addresses a bug where the Environmental Score is not calculated correctly in case Confidentiality Requirement (CR), Integrity Requirement (CR), and Availability Requirement (AR) are provided. Although there is a workaround, described in the attached ticket, this behavior seems to warrant a fix.